### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,9 @@ Adds options to keep tabs on page (sticky tabs) and to move extensions into a hi
 Restart interface to apply setting changes. Save settings by editing params in scipt.py or using settings.json
 
 https://github.com/xanthousm/text-gen-webui-ui_tweaks
+
+## dynamic_context
+A simple extension that replaces {{time}} and {{date}} on the current character's context with the current time and date respectively.
+Also adds time context (and optionally date) to the last prompt to add extra context to the AI response.
+
+https://github.com/elPatrixF/dynamic_context


### PR DESCRIPTION
Added dynamic_context extension.

A simple extension I made which replaces the tags {{time}}, {{date}} and {{weekday}} in the character's context with the current time, and date, respectively. Additionally it also adds the current time as extra information at the end of the prompt (and optionally the date too).

Can probably be extended to add extra bias, as conditionals using the current system time, but as of now it just prints the time as extra context (doesn't display in the conversation history)

EDIT:
Forgot to paste the link here too.
https://github.com/elPatrixF/dynamic_context