### PR TITLE
Add LLM_Buttplug extension to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,9 @@ https://github.com/xr4dsh/CodeRunner
 An extension for using [Piper](https://github.com/rhasspy/piper) text-to-speech (TTS) model for fast voice generation. The main objective is to provide a user-friendly experience for text generation with audio. This TTS system allows multiple languages, with quality-voices and fast synthesis (much faster than real-time).
 
 https://github.com/tijo95/piper_tts
+
+## LLM_Buttplug
+
+LLM Control Sex Toy by function calling.
+
+https://github.com/PsychoSmiley/LLM_Buttplug


### PR DESCRIPTION
Added My adult extension for control your obaa toy ;) 
- Expecting json [function eg.](https://gist.github.com/PsychoSmiley/9a54b5fdd934435f01ae5146fe516d89) but extension extract trigger word `stroke(intensity)` string for flexibility.