### PR TITLE
Add FunASR STT extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This is a directory of extensions for <https://github.com/oobabooga/text-generat
 
 If you create your own extension, you are welcome to submit it to this list in a PR.
 
+## FunASR STT
+
+Enter chat messages with a microphone using the local SenseVoiceSmall model.
+Supports Mandarin, Cantonese, English, Japanese, and Korean, with automatic
+CPU/CUDA selection and optional auto-submit.
+
+<https://github.com/LauraGPT/funasr_stt>
+
 
 
 ## context-progress-bar-text-generation-webui


### PR DESCRIPTION
## Summary

- add a standalone FunASR/SenseVoice microphone STT extension
- document its five supported languages, CPU/CUDA selection, and optional auto-submit
- follow the textgen contribution guideline that dependency-heavy extensions live outside the main repository

## Validation

- 11 Python tests pass, including the pinned `gradio==4.37.2+custom.21` `MultimodalTextbox` contract and UI construction
- 7 Node tests pass for microphone permission, stream cleanup, recorder failures, encoding order, and empty auto-submit
- real browser-style WebM audio transcribed on CPU with `funasr==1.3.27` and textgen's `transformers==5.6.*` pins
- `pip check`, Ruff, Actionlint, JavaScript syntax, and Python compilation pass

Tracks oobabooga/textgen#7593.
